### PR TITLE
Don't pollute global namespace with shelljs

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-require('shelljs/global');
+const shelljs = require('shelljs');
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
@@ -15,7 +15,7 @@ if (platform === 'linux') {
 function promistify(cmd, callback) {
 	callback = callback || function () {};
 	return new Promise((resolve, reject) => {
-		exec(cmd, (code, stdout, stderr) => {
+		shelljs.exec(cmd, (code, stdout, stderr) => {
       if (code !== 0) {
         reject(stderr);
         callback(stderr, null);


### PR DESCRIPTION
Change the import to a regular shelljs import so it won't pollute the global namespace.

This used to happen before this PR:
```
# node
Welcome to Node.js v16.17.0.
Type ".help" for more information.
> const aapt = require("aaptjs")
undefined
> test
[Function (anonymous)]
```